### PR TITLE
Created a server that will return files

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,8 +3,10 @@
 
 const { createServer } = require('./createServer');
 
+const PORT = 5701;
+
 createServer()
-  .listen(5701, () => {
-    console.log(`Server is running on http://localhost:${5701} 🚀`);
-    console.log('Available at http://localhost:5701');
+  .listen(PORT, () => {
+    console.log(`Server is running on http://localhost:${PORT} 🚀`);
+    console.log(`Available at http://localhost:${PORT}`);
   });

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -1,8 +1,51 @@
 'use strict';
 
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const FILE_PATH = '/file';
+const PUBLIC_PATH = '/public';
+
 function createServer() {
-  /* Write your code here */
-  // Return instance of http.Server class
+  const server = http.createServer((req, res) => {
+    const { pathname } = new URL(req.url, `http://${req.headers.host}`);
+
+    res.setHeader('Content-Type', 'text/plain');
+
+    if (!pathname.includes(FILE_PATH)) {
+      res.statusCode = 400;
+      res.end('Hint: for load file `pathname` must start with `/file/`');
+
+      return;
+    }
+
+    if (pathname.includes('//')) {
+      res.statusCode = 404;
+      res.end('Double "//" not supported.');
+
+      return;
+    }
+
+    let publicPath = pathname.replace(FILE_PATH, PUBLIC_PATH);
+
+    if (publicPath === PUBLIC_PATH || publicPath === `${PUBLIC_PATH}/`) {
+      publicPath = path.join(publicPath, 'index.html');
+    }
+
+    fs.readFile(`.${publicPath}`, (error, data) => {
+      if (error) {
+        res.statusCode = 404;
+        res.end(`${publicPath} not found.`);
+
+        return;
+      };
+      res.statusCode = 200;
+      res.end(data);
+    });
+  });
+
+  return server;
 }
 
 module.exports = {


### PR DESCRIPTION
If you try to pass `/file/../app.js` you will be redirected to `app.js`
How to stop this behavior? Or should I not do this and just check the pathname if it includes "/file/"?


