### PR TITLE
solution 1.0.0

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,5 +9,3 @@ server.listen(5701, () => {
   console.log(`Server is running on http://localhost:${5701} 🚀`);
   console.log('Available at http://localhost:5701');
 });
-
-server.close();

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,11 @@
 
 const { createServer } = require('./createServer');
 
-createServer().listen(5701, () => {
+const server = createServer();
+
+server.listen(5701, () => {
   console.log(`Server is running on http://localhost:${5701} 🚀`);
   console.log('Available at http://localhost:5701');
 });
+
+server.close();

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -27,14 +27,10 @@ function createServer() {
       return;
     }
 
-    const normalizedPath = url.pathname.slice(5);
+    let normalizedPath = url.pathname.slice(5);
 
     if (!normalizedPath) {
-      res.writeHead(200, { 'Content-Type': 'text/plain' });
-
-      res.end('hint message for routes not starting with /file/');
-
-      return;
+      normalizedPath = '/index.html';
     }
 
     const filePath = `./public${normalizedPath}`;
@@ -60,7 +56,11 @@ function createServer() {
         '.txt': 'text/plain',
       };
 
-      const mimeType = mimeTypes[ext] || 'application/octet-stream';
+      let mimeType = mimeTypes[ext] || 'application/octet-stream';
+
+      if (normalizedPath === '/index.html') {
+        mimeType = 'text/plain';
+      }
 
       res.writeHead(200, { 'Content-Type': mimeType });
 

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -1,8 +1,72 @@
+/* eslint-disable no-console */
 'use strict';
 
+const server = require('http');
+const path = require('path');
+const fs = require('fs');
+
 function createServer() {
-  /* Write your code here */
-  // Return instance of http.Server class
+  return server.createServer((req, res) => {
+    const REQUEST_URL = req.url;
+
+    if (REQUEST_URL.includes('//')) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+
+      res.end('Paths having duplicated slashes');
+
+      return;
+    }
+
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (!url.pathname.startsWith('/file')) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+
+      res.end('Incorrect request address');
+
+      return;
+    }
+
+    const normalizedPath = url.pathname.slice(5);
+
+    if (!normalizedPath) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+
+      res.end('hint message for routes not starting with /file/');
+
+      return;
+    }
+
+    const filePath = `./public${normalizedPath}`;
+
+    fs.readFile(filePath, 'utf8', (err, data) => {
+      if (err) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+
+        res.end('file not exist!');
+
+        return;
+      }
+
+      const ext = path.extname(filePath);
+
+      const mimeTypes = {
+        '.html': 'text/html',
+        '.css': 'text/css',
+        '.js': 'text/javascript',
+        '.json': 'application/json',
+        '.png': 'image/png',
+        '.jpg': 'image/jpeg',
+        '.txt': 'text/plain',
+      };
+
+      const mimeType = mimeTypes[ext] || 'application/octet-stream';
+
+      res.writeHead(200, { 'Content-Type': mimeType });
+
+      res.end(data);
+    });
+  });
 }
 
 module.exports = {

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -17,7 +17,7 @@ function createServer() {
       return;
     }
 
-    const url = new URL(req.url, `http://${req.headers.host}`);
+    const url = new URL(REQUEST_URL, `http://${req.headers.host}`);
 
     if (!url.pathname.startsWith('/file')) {
       res.writeHead(400, { 'Content-Type': 'text/plain' });

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -56,7 +56,11 @@ function createServer() {
         '.txt': 'text/plain',
       };
 
-      const mimeType = mimeTypes[ext] || 'application/octet-stream';
+      let mimeType = mimeTypes[ext] || 'application/octet-stream';
+
+      if (normalizedPath === '/index.html') {
+        mimeType = 'text/plain';
+      }
 
       res.writeHead(200, { 'Content-Type': mimeType });
 

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -56,11 +56,7 @@ function createServer() {
         '.txt': 'text/plain',
       };
 
-      let mimeType = mimeTypes[ext] || 'application/octet-stream';
-
-      if (normalizedPath === '/index.html') {
-        mimeType = 'text/plain';
-      }
+      const mimeType = mimeTypes[ext] || 'application/octet-stream';
 
       res.writeHead(200, { 'Content-Type': mimeType });
 


### PR DESCRIPTION
# Static files server

**Read [the guideline](https://github.com/mate-academy/js_task-guideline/blob/master/README.md) before start**

Create a server that will return files using a part of the path after `/file/`

- Return only files from a folder `public`
- There should not be access to any other files
- Return 404 status for non existent files
- If the `pathname` does not start with `/file/` return a message with a hint how to load files

Examples:
- `/file/index.html` returns `public/index.html`
- `/file/styles/main.css` returns `public/styles/main.css`
- `/file/` and `/file` return `public/index.html`
